### PR TITLE
Update MSVC builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -494,16 +494,7 @@ w64_build() {(
 
 msvc64_build() {(
 	ZIP="radare2-msvc_64-${VERSION}.zip"
-	builder="vs2015_64"
-	check "${ZIP}" && return
-	appveyor_download ${ZIP} ${builder}
-	output "${ZIP}"
-	rm "${ZIP}"
-)}
-
-msvc32_build() {(
-	ZIP="radare2-msvc_32-${VERSION}.zip"
-	builder="vs2015_32"
+	builder="vs2017_64"
 	check "${ZIP}" && return
 	appveyor_download ${ZIP} ${builder}
 	output "${ZIP}"
@@ -512,16 +503,7 @@ msvc32_build() {(
 
 msvc64_installer() {(
 	EXE="radare2_installer-msvc_64-${VERSION}.exe"
-	builder="vs2015_64"
-	check "${EXE}" && return
-	appveyor_download ${EXE} ${builder} 1
-	output "${EXE}"
-	rm "${EXE}"
-)}
-
-msvc32_installer() {(
-	EXE="radare2_installer-msvc_32-${VERSION}.exe"
-	builder="vs2015_32"
+	builder="vs2017_64"
 	check "${EXE}" && return
 	appveyor_download ${EXE} ${builder} 1
 	output "${EXE}"

--- a/main.sh
+++ b/main.sh
@@ -36,9 +36,7 @@ release_all() {
 
 	#w32_build x86
 	#w64_build x64
-	msvc32_build
 	msvc64_build
-	msvc32_installer
 	msvc64_installer
 	#docker_windows_build x86_64-w64-mingw32.static-gcc
 	# docker_windows_build i686-w64-mingw32.static-gcc
@@ -114,9 +112,7 @@ osx:
 windows:
 	x86
 	x64
-	msvc32
 	msvc64
-	msvc32_installer
 	msvc64_installer
 
 ios:
@@ -163,16 +159,8 @@ ios:
 	download radare2
 	docker_windows_build x86_64-w64-mingw32.static-gcc
 	;;
--msvc32_installer)
-	msvc32_installer
-	exit 0
-	;;
 -msvc64_installer)
 	msvc64_installer
-	exit 0
-	;;
--msvc32)
-	msvc32_build
 	exit 0
 	;;
 -msvc64)


### PR DESCRIPTION
Because we upgraded from VS2015 to VS2017 and deprecated Windows 32bit builds.